### PR TITLE
fix(webpack): require .ts version of native class extender

### DIFF
--- a/sdkAngular/app/vendor-platform.android.ts
+++ b/sdkAngular/app/vendor-platform.android.ts
@@ -9,6 +9,7 @@
 // placed here needs to be careful about its dependencies.
 
 require("application");
+
 if (!global["__snapshot"]) {
     // In case snapshot generation is enabled these modules will get into the bundle
     // but will not be required/evaluated.
@@ -17,5 +18,6 @@ if (!global["__snapshot"]) {
 
     require("ui/frame");
     require("ui/frame/activity");
-    require("./main-activity.android.js");
+    require("./main-activity.android.ts");
 }
+

--- a/sdkAngular/webpack.config.js
+++ b/sdkAngular/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = env => {
     const extensions = getExtensions(platform);
 
     const nativeClassExtenders = [
-        join(__dirname, "app/main-activity.android.js"),
+        join(__dirname, "app/main-activity.android.ts"),
     ];
 
     const config = {


### PR DESCRIPTION
This will fix webpack build failure if the .ts file is not transpiled.