### PR TITLE
fix(AoT): invoke method with correct parameters

### DIFF
--- a/sdkAngular/app/dataform/editors/autocomplete/dataform-autocomplete.component.html
+++ b/sdkAngular/app/dataform/editors/autocomplete/dataform-autocomplete.component.html
@@ -1,5 +1,5 @@
 <GridLayout rows="auto, *">
-	<Button text="check values" (tap)="checkValues($event)"></Button>
+	<Button text="check values" (tap)="checkValues()"></Button>
 	<!-- >> angular-dataform-autocomplete-html -->
 	<RadDataForm #dataform row="1" [source]="booking" tkExampleTitle tkToggleNavButton (propertyCommitted)="onPropertyCommitted($event)">
 		<TKEntityProperty tkDataFormProperty name="from" displayName="From:" index="0" autoCompleteDisplayMode="tokens" [valuesProvider]="fromProviders">


### PR DESCRIPTION
Method invocations in the component templates should match the method signatures from the component classes.