### PR TITLE
fix: DataForm json examples not webpackable

### DIFF
--- a/sdkAngular/webpack.config.js
+++ b/sdkAngular/webpack.config.js
@@ -92,6 +92,8 @@ module.exports = env => {
                 { from: "**/*.jpg" },
                 { from: "**/*.png" },
                 { from: "**/*.xml" },
+                { from: "**/person-model.json" },
+                { from: "**/person-metadata.json" },
             ]),
             // Generate a bundle starter script and activate it in package.json
             new nsWebpack.GenerateBundleStarterPlugin([


### PR DESCRIPTION
To reproduce:
```
tns run ios --bundle
```

navigate to DataForm/Getting started JSON - it is emply