### PR TITLE
refactor: replace NativeScriptModule with NativeScriptCommonModule

### DIFF
--- a/sdkAngular/app/autocomplete/autocomplete-examples.module.ts
+++ b/sdkAngular/app/autocomplete/autocomplete-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptUIAutoCompleteTextViewModule } from "nativescript-ui-autocomplete/angular";
@@ -28,11 +28,11 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUIAutoCompleteTextViewModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         AutoCompleteContainsModeComponent,

--- a/sdkAngular/app/calendar/calendar-examples.module.ts
+++ b/sdkAngular/app/calendar/calendar-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptUICalendarModule } from "nativescript-ui-calendar/angular";
@@ -21,12 +21,12 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUICalendarModule,
         NativeScriptUIListViewModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         CalendarLocalizationComponent,

--- a/sdkAngular/app/chart/chart-examples.module.ts
+++ b/sdkAngular/app/chart/chart-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptUIChartModule } from "nativescript-ui-chart/angular";
@@ -44,11 +44,11 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUIChartModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         ChartAnnotationsGridLineComponent,

--- a/sdkAngular/app/dataform/dataform-examples.module.ts
+++ b/sdkAngular/app/dataform/dataform-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptUIDataFormModule } from "nativescript-ui-dataform/angular";
@@ -42,11 +42,11 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUIDataFormModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         DataFormAdjustmentComponent,

--- a/sdkAngular/app/gauges/gauges-examples.module.ts
+++ b/sdkAngular/app/gauges/gauges-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptUIGaugeModule } from "nativescript-ui-gauge/angular";
@@ -15,11 +15,11 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUIGaugeModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         GaugesAnimationsComponent,

--- a/sdkAngular/app/listview/listview-examples.module.ts
+++ b/sdkAngular/app/listview/listview-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
@@ -46,12 +46,12 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUIListViewModule,
         NativeScriptFormsModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         ListViewGettingStartedComponent,

--- a/sdkAngular/app/sidedrawer/sidedrawer-examples.module.ts
+++ b/sdkAngular/app/sidedrawer/sidedrawer-examples.module.ts
@@ -1,5 +1,5 @@
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptUISideDrawerModule } from "nativescript-ui-sidedrawer/angular";
@@ -17,11 +17,11 @@ import { CommonDirectivesModule } from '../navigation/directives/common-directiv
 @NgModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [
-        NativeScriptModule,        
         CommonDirectivesModule,
         NativeScriptUISideDrawerModule,
         NativeScriptRouterModule,
-        NativeScriptRouterModule.forChild(routes)
+        NativeScriptRouterModule.forChild(routes),
+        NativeScriptCommonModule,
     ],
     declarations: [
         SideDrawerEventsComponent,


### PR DESCRIPTION
NativeScriptModule should be imported only in the root NgModule. For all
other feature modules, NativeScriptCommonModule should be used instead.
Check out https://github.com/NativeScript/nativescript-angular/pull/1196.